### PR TITLE
ci: add pytest workflow and import smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and test runner
+        run: python -m pip install -e . pytest
+
+      - name: Run tests
+        run: python -m pytest

--- a/tests/test_package_import.py
+++ b/tests/test_package_import.py
@@ -1,0 +1,5 @@
+import autoflow
+
+
+def test_package_metadata_is_importable():
+    assert autoflow.__version__


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow for pushes and PRs to `main`.
- Installs the package editable plus `pytest` and runs `python -m pytest`.
- Adds a minimal import smoke test so the first CI lane has a deterministic baseline while fuller tests are added.

## Verification
- `git apply --check /home/alce/.hermes/revenue_artifacts/autoflow_3_ci_pytest_patch_20260428T2158Z.diff`
- `git diff --check`
- `python3 -m py_compile tests/test_package_import.py`
- Fresh venv, lightweight local smoke path: `python -m pip install pytest && python -m pip install --no-deps -e . && python -m pytest -q` → `1 passed`

Note: a full dependency install was started locally, but this runner timed out while downloading/installing the heavy scientific stack (`vtk`/PyVista path). The GitHub Actions workflow intentionally uses normal `pip install -e . pytest` so CI will exercise the declared dependencies on the hosted runner.

Fixes #3
